### PR TITLE
travis: Enable address sanitizer with clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,23 @@ os:
   - osx
 
 compiler:
-  - clang
   - gcc
+  - clang
+
+env:
+  - USE_VALGRIND=1
+  - USE_ASAN=1
+
+matrix:
+  exclude:
+    - compiler: gcc
+      env: USE_ASAN=1
+    - os: osx
+      env: USE_VALGRIND=1
+  include:
+    - os: osx
+      compiler: gcc
+      env: ""
 
 addons:
   apt:
@@ -14,5 +29,6 @@ addons:
       - valgrind
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export MEMCHECK="valgrind -q --leak-check=full --error-exitcode=1"; fi
+  - if [[ "$USE_VALGRIND" ]]; then export MEMCHECK="valgrind -q --leak-check=full --error-exitcode=1"; fi
+  - if [[ "$USE_ASAN" ]]; then export CFLAGS="-fsanitize=address -fno-omit-frame-pointer"; fi
   - make && make check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -g -O2
+CFLAGS += -Wall -g -O2
 SRCS = hazmat.c randombytes.c sss.c tweetnacl.c
 OBJS := ${SRCS:.c=.o}
 


### PR DESCRIPTION
This PR changes the Travis configuration such that the CI will use clang's AddressSanitizer in addition to valgrind (when it is supported by the platform).