### PR TITLE
Revert "travis: Allow ASAN=1 to fail on linux because of LSAN bug"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ env:
   - USE_ASAN=1
 
 matrix:
-  allow_failures:
-    - os: linux
-      env: USE_ASAN=1
   exclude:
     - compiler: gcc
       env: USE_ASAN=1


### PR DESCRIPTION
This reverts commit b01263bdc9fce8716fb630f29073d62809bab855.

The LSAN bug seems to have been fixed. Re-enable ASAN on Linux.