### PR TITLE
added simple sss-create and sss-restore command-line tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS += -g -O2 -m64 -std=c99 -pedantic \
 SRCS = hazmat.c randombytes.c sss.c tweetnacl.c
 OBJS := ${SRCS:.c=.o}
 
-all: libsss.a
+all: libsss.a sss-create sss-restore
 
 libsss.a: randombytes/librandombytes.a $(OBJS)
 	$(AR) -rcs libsss.a $^
@@ -22,6 +22,12 @@ hazmat.o: CFLAGS += -funroll-loops
 
 test_hazmat.out: $(OBJS)
 test_sss.out: $(OBJS)
+
+sss-create: sss-create.c libsss.a
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS)
+
+sss-restore: sss-restore.c libsss.a
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS)
 
 .PHONY: check
 check: test_hazmat.out test_sss.out

--- a/sss-create.c
+++ b/sss-create.c
@@ -1,0 +1,44 @@
+#include "sss.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void usage(const char* self);
+
+void usage(const char* self) {
+  printf("usage %s <shares> <threshold> <prefix> <secret\n\twhere shares >= threshold, and\n\tthreshold >= 1, and\n\tlen(secret)==64\n", self);
+  exit(1);
+}
+
+int main(int argc, char **argv) {
+  if(argc!=4) usage(argv[0]);
+
+  int n, t;
+  n = atoi(argv[1]);
+  if(n<1) usage(argv[0]);
+  t = atoi(argv[2]);
+  if(n<t) usage(argv[0]);
+  fprintf(stderr,"[>] creating %d-%d shares\n", n, t);
+
+  sss_Share shares[n];
+  uint8_t data[sss_MLEN];
+  if(fread(data, sss_MLEN, 1, stdin)!=1) usage(argv[0]);
+
+  /* Split the secret into 5 shares (with a recombination theshold of 4) */
+  sss_create_shares(shares, data, n, t);
+
+  char fname[strlen(argv[3])+16/*hex seqno*/+4/*extension*/+1/*terminating 0*/];
+  memcpy(fname, argv[3], strlen(argv[3]));
+
+  long i;
+  FILE *f;
+  for(i=0;i<n;i++) {
+    snprintf(fname+strlen(argv[3]), 21, "%016x.sss", (int) i);
+    fprintf(stderr,"[>] writing share %ld to %s\n", i, fname);
+    f=fopen(fname,"w");
+    fwrite(shares[i], sizeof(sss_Share), 1, f);
+    fclose(f);
+  }
+
+  return 0;
+}

--- a/sss-restore.c
+++ b/sss-restore.c
@@ -1,0 +1,34 @@
+#include "sss.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void usage(const char* self);
+
+void usage(const char* self) {
+  printf("usage %s <no-of-shares> <shares >secret\n", self);
+  exit(1);
+}
+
+int main(int argc, char **argv) {
+  if(argc!=2) usage(argv[0]);
+
+  int n;
+  n = atoi(argv[1]);
+  if(n<1) usage(argv[0]);
+  fprintf(stderr,"[>] restoring from %d shares\n", n);
+
+  sss_Share shares[n];
+  uint8_t data[sss_MLEN];
+  if(fread(shares, sizeof(sss_Share), n, stdin)!=(size_t) n) usage(argv[0]);
+
+  /* /\* Combine some of the shares to restore the original secret *\/ */
+  if(sss_combine_shares(data, shares, n)!=0) {
+    fprintf(stderr,"failed to restore from shares\n");
+    exit(1);
+  }
+
+  fwrite(data,sss_MLEN,1,stdout);
+
+  return 0;
+}


### PR DESCRIPTION
they can be invoked by strictly following the simple example:
```
echo -n "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" | ./sss-create 5 4 test && cat test*[4230]* | ./sss-restore 4
```

TODO: if upstream accepts this: documentation.
      also cleaning of the memory of sensitive data*, if someone intends this to use for real
	   (sodium_memzero means dep to libsodium)